### PR TITLE
Searchable Updates/Model Unique ID

### DIFF
--- a/StatesFluInfo/ContentView.swift
+++ b/StatesFluInfo/ContentView.swift
@@ -11,11 +11,26 @@ struct ContentView: View {
     @State var searchText = ""
     @StateObject var dataTaskManager = DataTaskManager()
     
+    // Since you already have the flu vaccine info when it's initially displayed,
+    // you don't have to make another network call to search through that data
+    // Here is a way to filter through results in real time (as the user types
+    // in the search bar) and the cancel button works now as well :)
+    var filteredStates: [FluVaccineInfo] {
+        if searchText.isEmpty {
+            return dataTaskManager.dataToView
+        } else {
+            return dataTaskManager.dataToView.filter { $0.geography.localizedCaseInsensitiveContains(searchText)
+            }
+        }
+    }
+    
     var body: some View {
         NavigationView {
             List{
-                
-                ForEach(dataTaskManager.dataToView, id: \.self) { state in
+                // Instead of dataTaskManger.dataToView, we can now use filteredStates
+                // which handles updating the list based on the search text
+                // The model also now has a unique id which can be used here (see the Model file)
+                ForEach(filteredStates, id: \.id) { state in
                     if validateResponse(var1: state.dimension, var2: state.year_season) {
                         NavigationLink(destination: StateInfoLink(fluVaccine: state)) {
                             HStack{
@@ -37,18 +52,16 @@ struct ContentView: View {
                 dataTaskManager.fetch()
             }
         }
-        .onSubmit (of: .search)
-        {
-            dataTaskManager.searchFetch(searchTerm: searchText)
-        }
+//        .onSubmit (of: .search)
+//        {
+//            dataTaskManager.searchFetch(searchTerm: searchText)
+//        }
     }
     
+    // No need to have if/else return true/false here (unless this is more confusing!)
+    // This one line statement will do the same thing
     func validateResponse(var1: String, var2: String) -> Bool {
-        if var1 == "25-34 Years" && var2 == "2017" {
-            return true
-        } else {
-            return false
-        }
+        var1 == "25-34 Years" && var2 == "2017"
     }
 }
 

--- a/StatesFluInfo/Model.swift
+++ b/StatesFluInfo/Model.swift
@@ -8,8 +8,21 @@
 import Foundation
 
 struct FluVaccineInfo: Codable, Hashable {
+    // In order to resolve the console issue that says:
+    // "the id occurs multiple times within the collection,
+    // this will give undefined results!", you can add a unique
+    // identifier for each model object
+    var id = UUID()
+    
     var geography: String
     var coverage_estimate: String
     var year_season: String
     var dimension: String
+    
+    // However, this will be required now so Codable knows that the id variable
+    // won't be in the json that you download from the network
+    // (CodingKeys will tell Codable to only encode/decode these specific variables)
+    enum CodingKeys: String, CodingKey {
+        case geography, coverage_estimate, year_season, dimension
+    }
 }

--- a/StatesFluInfo/NetworkManager.swift
+++ b/StatesFluInfo/NetworkManager.swift
@@ -33,21 +33,21 @@ class DataTaskManager: ObservableObject {
             .store(in: &cancellables)
     }
     
-    func searchFetch(searchTerm: String) {
-        let url = URL(string: "https://data.cdc.gov/resource/h7pm-wmjc.json?geography=\(searchTerm)")!
-        URLSession.shared.dataTaskPublisher(for: url)
-            .map { $0.data }
-            .decode(type: [FluVaccineInfo].self, decoder: JSONDecoder())
-            .receive(on: RunLoop.main)
-            .sink { completion in
-                if case .failure(let error) = completion {
-                    print("Error: \(error.localizedDescription)")
-                }
-            } receiveValue: { [unowned self] response in
-                dataToView = response
-                print(response)
-            }
-            .store(in: &cancellables)
-    }
+//    func searchFetch(searchTerm: String) {
+//        let url = URL(string: "https://data.cdc.gov/resource/h7pm-wmjc.json?geography=\(searchTerm)")!
+//        URLSession.shared.dataTaskPublisher(for: url)
+//            .map { $0.data }
+//            .decode(type: [FluVaccineInfo].self, decoder: JSONDecoder())
+//            .receive(on: RunLoop.main)
+//            .sink { completion in
+//                if case .failure(let error) = completion {
+//                    print("Error: \(error.localizedDescription)")
+//                }
+//            } receiveValue: { [unowned self] response in
+//                dataToView = response
+//                print(response)
+//            }
+//            .store(in: &cancellables)
+//    }
     
 }


### PR DESCRIPTION
- Since the flu vaccine info data is fetched from the network initially, you can use the data you already have to filter the list as the user types in the search bar; added filteredStates variable to handle this
- Noticed the console showing a warning that said “the id occurs multiple times within the collection, this will give undefined results!” so I added a unique identifer to the FluVaccineInfo model object so the List could differentiate between objects with the same strings
- Updated the validateResponse function to one line; one line functions don’t require the ‘return’ keyword (it is implicit)
- Commented out unused code with this change
- Added comments in the project to explain each change